### PR TITLE
Add opdesc and inst directive

### DIFF
--- a/example.vsh
+++ b/example.vsh
@@ -48,6 +48,12 @@
 	; Set vertex color
 	mov outclr.xyz, inarg
 	mov outclr.w, ones
+
+	; Random raw encoded nop
+	.opdesc nop_opdesc 0x00000000 0x00FFFF00 ; Adds an opdesc with value 0 and mask 0x00FFFF00 (last argument is optional)
+	.opdesc nop_opdesc2 0x12345678 ; Adds an opdesc with value 0 and mask 0xFFFFFFFF
+	.inst 0x84000000 nop_opdesc; nop but lower bits will become index of opdesc
+	.inst 0x84000000 ; nop with opdesc 0
 	
 	end
 .end

--- a/source/picasso.h
+++ b/source/picasso.h
@@ -126,12 +126,14 @@ typedef std::pair<size_t, std::string> relocation; // position, name
 typedef std::map<std::string, procedure> procTableType;
 typedef std::map<std::string, size_t> labelTableType;
 typedef std::map<std::string, int> aliasTableType;
+typedef std::map<std::string, int> opdescTableType;
 typedef std::vector<relocation> relocTableType;
 typedef std::list<DVLEData> dvleTableType;
 
 typedef procTableType::iterator procTableIter;
 typedef labelTableType::iterator labelTableIter;
 typedef aliasTableType::iterator aliasTableIter;
+typedef opdescTableType::iterator opdescTableIter;
 typedef relocTableType::iterator relocTableIter;
 typedef dvleTableType::iterator dvleTableIter;
 
@@ -144,6 +146,7 @@ extern int g_totalDvleCount;
 extern labelTableType g_labels;
 extern relocTableType g_labelRelocTable;
 extern aliasTableType g_aliases;
+extern opdescTableType g_opdescs;
 
 int AssembleString(char* str, const char* initialFilename);
 int RelocateProduct(void);


### PR DESCRIPTION
.Okay.. this is really ugly.
However, it should get the job done for what I intend. I'm not sure if this is useful for anybody else or if it might even be considered a usable feature. So I'll PR this here and you can feel free to do whatever you want.

As citra had bad mad encoding I wanted a way to test different encodings.
Hence I added .inst and .opdesc to picasso.
- .opdesc <opdescName> <data> [mask]
  This will add a named entry to the opdesc table with a given data-value and an optional mask to reuse existing entries.
  Ideally you'd want those at the top of the file before any instructions so you know your opdesc indices.
- .inst <data> [opdescName]
  This will add a raw u32 into the instruction buffer. The optional opdesc name can be used to OR the data with an opdesc index from the named opdescs.

This is entirely untested yet (I didn't try running or disassembling a single shader or anything). I only compiled and assembled some files and made sure that my handlers are called
I'll use this soon to figure out the proper MADI encoding and CMP masking.
