### PR TITLE
picasso_assembler: Put bounds check before indexing the string in parseSwizzling

### DIFF
--- a/source/picasso_assembler.cpp
+++ b/source/picasso_assembler.cpp
@@ -524,7 +524,7 @@ static inline int ensure_valid_condop(int condop, const char* name)
 static int parseSwizzling(const char* b)
 {
 	int i, out = 0, q = COMP_X;
-	for (i = 0; b[i] && i < 4; i ++)
+	for (i = 0; i < 4 && b[i]; i ++)
 	{
 		switch (tolower(b[i]))
 		{


### PR DESCRIPTION
It's unlikely to be an issue, but this just errs on the safe side of things