### PR TITLE
picasso_assembler: Silence a -Wlogical-op-parenthesis warning

### DIFF
--- a/source/picasso_assembler.cpp
+++ b/source/picasso_assembler.cpp
@@ -787,7 +787,7 @@ static int parseReg(char* pos, int& outReg, int& outSw, int* idxType = NULL)
 				return throwError("invalid boolean uniform register: %s\n", pos);
 			break;
 	}
-	if (idxType && *idxType && outReg < 0x20 || outReg >= 0x80)
+	if (idxType && *idxType && (outReg < 0x20 || outReg >= 0x80))
 		return throwError("index register not allowed with this kind of register\n");
 	outReg += regOffset;
 	return 0;


### PR DESCRIPTION
Occurs when building on macOS with clang