### PR TITLE
picasso_assembler: Silence a -Wmissing-prototypes warning

### DIFF
--- a/source/picasso_assembler.cpp
+++ b/source/picasso_assembler.cpp
@@ -1755,7 +1755,7 @@ DEF_DIRECTIVE(setfi)
 	return 0;
 }
 
-int parseBool(bool& out, const char* text)
+static int parseBool(bool& out, const char* text)
 {
 	if (stricmp(text, "true")==0 || stricmp(text, "on")==0 || stricmp(text, "1")==0)
 	{


### PR DESCRIPTION
This is only used in this translation unit. Occurs when building with clang. I must have missed this when I fixed the other warning in #18 somehow (my bad!)