### PR TITLE
Added cmake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ Makefile
 picasso
 .deps/
 *.bz2
+
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.0)
+project (picasso VERSION 2.7.1)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin) 
+add_library(picasso source/picasso_assembler.cpp)
+add_executable(picasso_frontend source/picasso_frontend.cpp)
+target_link_libraries(picasso_frontend picasso)
+add_compile_definitions(PACKAGE_STRING="${PROJECT_NAME} ${PROJECT_VERSION}")
+set_target_properties(picasso_frontend PROPERTIES OUTPUT_NAME "${PROJECT_NAME}")


### PR DESCRIPTION
This should make it easier to build out of the box on windows and mac
I did it in a way where it builds the assembler as a library and the frontend as an executable statically linking the library since I plan to try to refactor picasso in order to make it easily usable as a library for 3ds homebrew (for my godot engine 3ds port)
where we could just call an assemble function from the homebrew and give a pointer to the assembler file data and it would return the compiled shader